### PR TITLE
Securing workflow for supabase migrations

### DIFF
--- a/.github/workflows/migrate.yaml
+++ b/.github/workflows/migrate.yaml
@@ -8,16 +8,13 @@ on:
         type: choice
         options:
           - production
-      supabase_access_token:
-        description: 'Short-Lived (1H) Supabase Personal Access Token (PAT)'
-        requied: true
-        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: database-migration
+  group: database-migration-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
 
 jobs:
   migrate:
@@ -28,10 +25,6 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
 
-      - name: Mask Supabase Personal Access Token
-        shell: bash
-        run: echo "::add-mask::${{ github.event.inputs.supabase_access_token }}"
-
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
@@ -40,7 +33,7 @@ jobs:
       - name: Link Project and Migrate
         env:
           SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
-          SUPABASE_ACCESS_TOKEN: ${{ github.event.inputs.supabase_access_token }}
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DATABASE_PASSWORD }}
           run: |
             supabase link --project-ref $SUPABASE_PROJECT_ID


### PR DESCRIPTION
Relates to #8 

I was originally avoiding trying to create a "service account" (shared supabase account) but after looking at other projects and doing more research it seems like this is the only proper way to go about it. It's possible to just use someone (my) personal access token, but since it controls their (my) account, it doesn't feel right to have anyone with write access to this repo to potentially do things in their (my) account.