### PR TITLE
fixing migration workflow to use project supabase configs

### DIFF
--- a/.github/workflows/migrate.yaml
+++ b/.github/workflows/migrate.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'GitHub environment for database migration'
+        description: "GitHub environment for database migration"
         required: true
         type: choice
         options:
@@ -22,20 +22,28 @@ jobs:
     environment: ${{ github.event.inputs.environment }}
 
     steps:
-      - name: Git Checkout
+      - name: git checkout
         uses: actions/checkout@v4
 
-      - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+      - name: install pnpm
+        uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: "10.18.2"
 
-      - name: Link Project and Migrate
+      - name: setup node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/jod
+          cache: "pnpm"
+
+      - name: install dependencies
+        run: pnpm install
+
+      - name: link supabase project and deploy
         env:
           SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DATABASE_PASSWORD }}
         run: |
-          supabase link --project-ref $SUPABASE_PROJECT_ID
-          supabase config push
-          supabase db push
+          pnpm --filter database exec supabase link --project-ref $SUPABASE_PROJECT_ID
+          pnpm --filter database deploy

--- a/database/package.json
+++ b/database/package.json
@@ -12,7 +12,10 @@
     "migration:up": "supabase migration up",
     "migration:new": "supabase migration new",
     "lint": "supabase db lint",
-    "test": "echo OK"
+    "test": "echo OK",
+    "deploy": "pnpm deploy:config && pnpm deploy:db",
+    "deploy:config": "supabase config push",
+    "deploy:db": "supabase db push"
   },
   "devDependencies": {
     "supabase": "^2.54.11"


### PR DESCRIPTION
The project is setup as a monorepo via pnpm workspaces and we already include supabase as part of the subproject's dev dependencies. To limit any configuration drift, we can just install the cli via pnpm and execute any scripts through pnpm as well.